### PR TITLE
[confluence-search] Catch site var being undefined during initial search.

### DIFF
--- a/extensions/confluence-search/CHANGELOG.md
+++ b/extensions/confluence-search/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Confluence Changelog
 
+## [Bug fix] - 2024-04-15
+
+- Fix a bug causing the Search panel to not work when it is the first one used
+    after the initial setup.
+
 ## [Bug fix] - 2023-11-19
 
-- Fixed a bug causing the People panel to not open
+- Fix a bug causing the People panel to not open.
 
 ## [Update] - 2023-03-01
 

--- a/extensions/confluence-search/package.json
+++ b/extensions/confluence-search/package.json
@@ -5,10 +5,8 @@
   "description": "Quickly navigate, create and search Confluence through Raycast.",
   "icon": "command-icon.png",
   "author": "tbrown",
-  "categories": [
-    "Productivity",
-    "Documentation"
-  ],
+  "contributors": ["ahoereth"],
+  "categories": ["Productivity", "Documentation"],
   "license": "MIT",
   "commands": [
     {

--- a/extensions/confluence-search/src/search.tsx
+++ b/extensions/confluence-search/src/search.tsx
@@ -112,6 +112,13 @@ function useSearch(site?: any) {
         ...oldState,
         isLoading: true,
       }));
+      // During the very initial call to this function after setup, site is
+      // still undefined. Not catching that here can result in the Search
+      // component not working permanently as it won't be able to setup the site
+      // variable at all.
+      if (site === undefined) {
+        return;
+      }
       try {
         const results = await performSearch(site, searchText, spaceFilter, cancelRef.current.signal);
 


### PR DESCRIPTION
## Description

Was unable to re-setup the confluence-search extension due to an exception I wasn't able to bypass from the UI.

The following is the exception, this PR fixes it. Extension works as intended after the change. 

```
❯ npm run dev                                                                                                                                                                                                          9:07

> dev
> ray develop

info  -  entry points [src/search.tsx src/people.tsx src/recent.tsx src/popular.tsx src/go.tsx src/switch-site.tsx src/new-page.tsx src/new-blog.tsx]
ready -  built extension successfully
09:07:04.180 GET https://api.atlassian.com/oauth/token/accessible-resources
09:07:04.180 search error TypeError: Cannot read properties of undefined (reading 'id')
    at fetchSearchByCql (.../.config/raycast/extensions/confluence/search.js:34784:71)
    at async performSearch (.../.config/raycast/extensions/confluence/search.js:35181:27)
    at async search2 (.../.config/raycast/extensions/confluence/search.js:35134:25)
09:07:04.182 The above error occurred in the <Command> component:

    at Command (../.config/raycast/extensions/confluence/search.js:35048:16)
    at Or (/Applications/Raycast.app/Contents/Resources/RaycastNodeExtensions_RaycastNodeExtensions.bundle/Contents/Resources/api/node_modules/@raycast/api/index.js:11:2490)
    at ray-navigation-stack
    at Ro (/Applications/Raycast.app/Contents/Resources/RaycastNodeExtensions_RaycastNodeExtensions.bundle/Contents/Resources/api/node_modules/@raycast/api/index.js:11:2088)
    at Suspense
    at ko (/Applications/Raycast.app/Contents/Resources/RaycastNodeExtensions_RaycastNodeExtensions.bundle/Contents/Resources/api/node_modules/@raycast/api/index.js:10:1022)
    at ray-root
    at Li (/Applications/Raycast.app/Contents/Resources/RaycastNodeExtensions_RaycastNodeExtensions.bundle/Contents/Resources/api/node_modules/@raycast/api/index.js:11:3000)

React will try to recreate this component tree from scratch using the error boundary you provided, InternalErrorBoundary.
09:07:04.234 
TypeError: Cannot read properties of undefined (reading 'url')

Command:search.tsx:26:15

---
23: const { searchAttachments, sort } = getPreferenceValues();
24: 
25: export default function Command() {
26:   const site = useAuthorizeSite();
27:   const { state, search } = useSearch(site);
28:   const [spaces, setSpaces] = useState([]) as any[];
29: 
---

Or:index.js:11:2490
    at ray-navigation-stack
Ro:index.js:11:2088
```

## Screencast

/

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
